### PR TITLE
Fix the bug when the input_size of the model was not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## neptune-tensorflow-keras 1.1.0
+
+### Fixes
+
+- We fixed a bug that crashed the integration with an error message ``ValueError: This model has not yet been built. Build the model first by calling `build()` or by calling the model on a batch of data.``, when the input layer of a neural network didn't have the `input_shape`
+  parameter defined or the model was not built.
+
 ## neptune-tensorflow-keras 1.0.0
 
 ### Added

--- a/neptune_tensorflow_keras/impl/__init__.py
+++ b/neptune_tensorflow_keras/impl/__init__.py
@@ -140,13 +140,13 @@ class NeptuneCallback(Callback):
         self._model_logger["optimizer_config"] = self.model.optimizer.get_config()  # it is a dict
         self._metric_logger["fit_params"] = self.params
 
-        if self._log_model_diagram:
-            self._model_logger["visualization"] = _model_diagram(self.model)
-
     def on_train_end(self, logs=None):  # pylint:disable=unused-argument
         # We need this to be logged at the end of the training, otherwise we are risking this to happen:
         # https://stackoverflow.com/q/55908188/3986320
         self._model_logger["summary"] = _model_summary_file(self.model)
+
+        if self._log_model_diagram:
+            self._model_logger["visualization"] = _model_diagram(self.model)
 
     def on_train_batch_end(self, batch, logs=None):  # pylint:disable=unused-argument
         if self._log_on_batch:

--- a/neptune_tensorflow_keras/impl/__init__.py
+++ b/neptune_tensorflow_keras/impl/__init__.py
@@ -41,7 +41,7 @@ try:
     # neptune-client=0.9.0+ package structure
     from neptune.new import Run
     from neptune.new.exceptions import NeptuneException
-    from neptune.new.integrations.utils import verify_type, expect_not_an_experiment
+    from neptune.new.integrations.utils import expect_not_an_experiment, verify_type
     from neptune.new.types import File
 except ImportError:
     # neptune-client>=1.0.0 package structure
@@ -136,7 +136,7 @@ class NeptuneCallback(Callback):
             except NeptuneException:
                 pass
 
-    def on_train_begin(self, logs=None):  # pylint:disable=unused-argument
+    def on_train_end(self, logs=None):  # pylint:disable=unused-argument
         self._model_logger["summary"] = _model_summary_file(self.model)
         self._model_logger["optimizer_config"] = self.model.optimizer.get_config()  # it is a dict
         self._metric_logger["fit_params"] = self.params
@@ -149,7 +149,7 @@ class NeptuneCallback(Callback):
             self._log_metrics(logs, "train", "batch")
 
     def on_epoch_begin(self, epoch, logs=None):  # pylint:disable=unused-argument
-        self._model_logger['learning_rate'].log(self.model.optimizer.learning_rate)
+        self._model_logger["learning_rate"].log(self.model.optimizer.learning_rate)
 
     def on_epoch_end(self, epoch, logs=None):  # pylint:disable=unused-argument
         self._log_metrics(logs, "train", "epoch")

--- a/neptune_tensorflow_keras/impl/__init__.py
+++ b/neptune_tensorflow_keras/impl/__init__.py
@@ -136,13 +136,17 @@ class NeptuneCallback(Callback):
             except NeptuneException:
                 pass
 
-    def on_train_end(self, logs=None):  # pylint:disable=unused-argument
-        self._model_logger["summary"] = _model_summary_file(self.model)
+    def on_train_begin(self, logs=None):  # pylint:disable=unused-argument
         self._model_logger["optimizer_config"] = self.model.optimizer.get_config()  # it is a dict
         self._metric_logger["fit_params"] = self.params
 
         if self._log_model_diagram:
             self._model_logger["visualization"] = _model_diagram(self.model)
+
+    def on_train_end(self, logs=None):  # pylint:disable=unused-argument
+        # We need this to be logged at the end of the training, otherwise we are risking this to happen:
+        # https://stackoverflow.com/q/55908188/3986320
+        self._model_logger["summary"] = _model_summary_file(self.model)
 
     def on_train_batch_end(self, batch, logs=None):  # pylint:disable=unused-argument
         if self._log_on_batch:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,8 @@ def dataset():
 def model():
     model = tf.keras.models.Sequential(
         [
-            # We are *not* providing input_size to the first layer, so the test catch also the case where the
-            # model was not build yet (e.g. on_train_begin): https://stackoverflow.com/q/55908188/3986320
+            # We are *not* providing input_size to the first layer, so the test will catch also the case where the
+            # model was not build yet: https://stackoverflow.com/q/55908188/3986320
             tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(10),
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,9 @@ def dataset():
 def model():
     model = tf.keras.models.Sequential(
         [
-            tf.keras.layers.Flatten(input_shape=(28, 28)),
+            # We are *not* providing input_size to the first layer, so the test catch also the case where the
+            # model was not build yet (e.g. on_train_begin): https://stackoverflow.com/q/55908188/3986320
+            tf.keras.layers.Flatten(),
             tf.keras.layers.Dense(10),
         ]
     )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -32,7 +32,7 @@ def test_e2e(dataset, model, log_model_diagram, log_on_batch):
         validation_data=(x_test, y_test),
     )
 
-    # retry if Neptune didn't reresh its cache
+    # retry if Neptune didn't refresh its cache
     num_tries = 5
     for i in range(num_tries):
         try:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,3 +1,5 @@
+import time
+
 import numpy.testing as npt
 import pytest
 
@@ -6,9 +8,11 @@ from neptune_tensorflow_keras.impl import NeptuneCallback
 try:
     # neptune-client=0.9.0+ package structure
     from neptune.new import init_run
+    from neptune.new.exceptions import FetchAttributeNotFoundException
 except ImportError:
     # neptune-client>=1.0.0 package structure
     from neptune import init_run
+    from neptune.exceptions import FetchAttributeNotFoundException
 
 
 @pytest.mark.parametrize("log_model_diagram", [True, False])
@@ -28,6 +32,19 @@ def test_e2e(dataset, model, log_model_diagram, log_on_batch):
         validation_data=(x_test, y_test),
     )
 
+    # retry if Neptune didn't reresh its cache
+    num_tries = 5
+    for i in range(num_tries):
+        try:
+            validate_results(run, log_model_diagram, log_on_batch)
+            return
+        except FetchAttributeNotFoundException:
+            time.sleep(i + 1)
+    else:
+        raise RuntimeError("Test failed to fetch the data from Neptune")
+
+
+def validate_results(run, log_model_diagram, log_on_batch):
     base_namespace = "training"
 
     for subset in ["train", "validation"]:


### PR DESCRIPTION
We were saving metrics on `on_train_begin` but there is an edge case in TensorFlow where the model is not ready yet before the training starts, so our integration was crashing. The test was adjusted to catch that (it fails correctly). 