### PR TITLE
Remove misleading information from the docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## neptune-tensorflow-keras 1.2.1
+
+### Fixes
+- Remove misleading information from the docstring. Pydot is needed when saving the model diagram.
+
 ## neptune-tensorflow-keras 1.2.0
 
 ### Changes

--- a/src/neptune_tensorflow_keras/impl/__init__.py
+++ b/src/neptune_tensorflow_keras/impl/__init__.py
@@ -71,7 +71,7 @@ class NeptuneCallback(Callback):
             logged by the NeptuneCallback will be stored. Defaults to "training".
         log_on_batch (`bool`): Log the metrics also for each batch, not only each epoch.
         log_model_diagram (`bool`): Save the model visualization. Defaults to False.
-            Requires pydot to be installed, otherwise it will silently skip saving the diagram.
+            This functionality requires pydot to be installed.
 
     Example:
 

--- a/src/neptune_tensorflow_keras/impl/__init__.py
+++ b/src/neptune_tensorflow_keras/impl/__init__.py
@@ -71,7 +71,7 @@ class NeptuneCallback(Callback):
             logged by the NeptuneCallback will be stored. Defaults to "training".
         log_on_batch (`bool`): Log the metrics also for each batch, not only each epoch.
         log_model_diagram (`bool`): Save the model visualization. Defaults to False.
-            This functionality requires pydot to be installed.
+            This functionality requires pydot to be installed (https://pypi.org/project/pydot/).
 
     Example:
 


### PR DESCRIPTION
The information in the docstring was misleading. Silent failing is an anti-pattern, so fixing the docstring should be enough.