### PR TITLE
Integration update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pre-commit = { version = "*", optional = true }
 pytest = { version = ">=5.0", optional = true }
 pytest-cov = { version = "2.10.1", optional = true }
 pydot = { version = "*", optional = true }
+neptune = { version = ">=1.0.0", optional = true }
 
 [tool.poetry.extras]
 dev = [
@@ -28,6 +29,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "pydot",
+    "neptune",
 ]
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ python = "^3.7"
 # Python lack of functionalities from future versions
 importlib-metadata = { version = "*", python = "<3.8" }
 
-neptune = ">=1.0.0"
 tensorflow = ">2.0.0"
 
 # dev

--- a/src/neptune_tensorflow_keras/impl/__init__.py
+++ b/src/neptune_tensorflow_keras/impl/__init__.py
@@ -41,22 +41,34 @@ except ImportError as exc:
         raise ModuleNotFoundError(msg) from exc
 
 try:
-    # neptune-client=0.9.0+ package structure
-    import neptune.new as neptune
-    from neptune.new.exceptions import NeptuneException
-    from neptune.new.integrations.utils import (
-        expect_not_an_experiment,
-        verify_type,
-    )
-    from neptune.new.types import File
-    from neptune.new.utils import stringify_unsupported
-except ImportError:
     # neptune-client>=1.0.0 package structure
     import neptune
     from neptune.exceptions import NeptuneException
-    from neptune.integrations.utils import verify_type, expect_not_an_experiment
+    from neptune.integrations.utils import (
+        expect_not_an_experiment,
+        verify_type,
+    )
     from neptune.types import File
     from neptune.utils import stringify_unsupported
+except ImportError:
+    try:
+        # neptune-client=0.9.0+ package structure
+        import neptune.new as neptune
+        from neptune.new.exceptions import NeptuneException
+        from neptune.new.integrations.utils import (
+            expect_not_an_experiment,
+            verify_type,
+        )
+        from neptune.new.types import File
+        from neptune.new.utils import stringify_unsupported
+    except ImportError as exc:
+        msg = """
+                neptune package not found.
+
+                Install neptune package by running
+                    `pip install neptune`
+            """
+        raise ModuleNotFoundError(msg) from exc
 
 from neptune_tensorflow_keras.impl.version import __version__
 

--- a/src/neptune_tensorflow_keras/impl/__init__.py
+++ b/src/neptune_tensorflow_keras/impl/__init__.py
@@ -40,6 +40,8 @@ except ImportError as exc:
             pip install tensorflow"""
         raise ModuleNotFoundError(msg) from exc
 
+from neptune_tensorflow_keras.impl.version import __version__
+
 try:
     # neptune-client>=1.0.0 package structure
     import neptune
@@ -51,26 +53,16 @@ try:
     from neptune.types import File
     from neptune.utils import stringify_unsupported
 except ImportError:
-    try:
-        # neptune-client=0.9.0+ package structure
-        import neptune.new as neptune
-        from neptune.new.exceptions import NeptuneException
-        from neptune.new.integrations.utils import (
-            expect_not_an_experiment,
-            verify_type,
-        )
-        from neptune.new.types import File
-        from neptune.new.utils import stringify_unsupported
-    except ImportError as exc:
-        msg = """
-                neptune package not found.
+    # neptune-client=0.9.0+ package structure
+    import neptune.new as neptune
+    from neptune.new.exceptions import NeptuneException
+    from neptune.new.integrations.utils import (
+        expect_not_an_experiment,
+        verify_type,
+    )
+    from neptune.new.types import File
+    from neptune.new.utils import stringify_unsupported
 
-                Install neptune package by running
-                    `pip install neptune`
-            """
-        raise ModuleNotFoundError(msg) from exc
-
-from neptune_tensorflow_keras.impl.version import __version__
 
 INTEGRATION_VERSION_KEY = "source_code/integrations/neptune-tensorflow-keras"
 

--- a/src/neptune_tensorflow_keras/impl/version.py
+++ b/src/neptune_tensorflow_keras/impl/version.py
@@ -1,6 +1,7 @@
 __all__ = ["__version__"]
 
 import sys
+from importlib.util import find_spec
 
 if sys.version_info >= (3, 8):
     from importlib.metadata import (
@@ -12,6 +13,15 @@ else:
         PackageNotFoundError,
         version,
     )
+
+if not (find_spec("neptune") or find_spec("neptune-client")):
+    msg = """
+            neptune package not found.
+
+            Install neptune package by running
+                `pip install neptune`
+                    """
+    raise PackageNotFoundError(msg)
 
 try:
     __version__ = version("neptune-tensorflow-keras")

--- a/src/neptune_tensorflow_keras/impl/version.py
+++ b/src/neptune_tensorflow_keras/impl/version.py
@@ -16,11 +16,12 @@ else:
 
 if not (find_spec("neptune") or find_spec("neptune-client")):
     msg = """
-            neptune package not found.
+            The Neptune client library was not found.
 
-            Install neptune package by running
+            Install the neptune package with
                 `pip install neptune`
-                    """
+            
+            Need help? -> https://docs.neptune.ai/setup/installation/"""
     raise PackageNotFoundError(msg)
 
 try:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -4,11 +4,11 @@ import pytest
 from neptune_tensorflow_keras.impl import NeptuneCallback
 
 try:
-    # neptune-client=0.9.0+ package structure
-    from neptune.new import init_run
-except ImportError:
     # neptune-client>=1.0.0 package structure
     from neptune import init_run
+except ImportError:
+    # neptune-client=0.9.0+ package structure
+    from neptune.new import init_run
 
 
 @pytest.mark.parametrize("log_model_diagram", [True, False])


### PR DESCRIPTION
## What's changing:
- neither `neptune` nor `neptune-client` is part of the requirements
- integration stays compatible with both major versions of the client
- in case neither `neptune` nor `neptune-client` is installed, an appropriate exception is raised with instructions for installation