### PR TITLE
fix learning_rate logging on multigpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## neptune-tensorflow-keras 2.2.0
+
+### Fixes
+- Support logging learning_rate in Multi-GPU training set-up ([#57](https://github.com/neptune-ai/neptune-tensorflow-keras/pull/57))
+
 ## neptune-tensorflow-keras 2.1.0
 
 ### Changes

--- a/src/neptune_tensorflow_keras/impl/__init__.py
+++ b/src/neptune_tensorflow_keras/impl/__init__.py
@@ -164,7 +164,7 @@ class NeptuneCallback(Callback):
             self._log_metrics(logs, "train", "batch")
 
     def on_epoch_begin(self, epoch, logs=None):
-        self._model_logger["learning_rate"].append(self.model.optimizer.learning_rate)
+        self._model_logger["learning_rate"].append(self.model.optimizer.learning_rate.numpy())
 
     def on_epoch_end(self, epoch, logs=None):
         self._log_metrics(logs, "train", "epoch")


### PR DESCRIPTION
This allows logging `lr` in a multi-gpu training set-up. 

`lr` could be `tf.Variable` or `tf.MirroredVariable` or something else based on distributed strategy (which neptune doesn't support logging). We call `numpy` to get a numpy object which we know to handle.