### PR TITLE
Handled additional kwargs passed to `model.summary()`'s `print_fn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## neptune-tensorflow-keras 2.2.2
 
-### Changes
-- `RuntimeWarning` replaced by `NeptuneWarning` if model summary or diagram cannot be logged ([#61](https://github.com/neptune-ai/neptune-tensorflow-keras/pull/61))
-
 ### Fixes
 - Handled additional kwargs passed to `model.summary()`'s `print_fn` ([#61](https://github.com/neptune-ai/neptune-tensorflow-keras/pull/61))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## neptune-tensorflow-keras 2.2.2
+
+### Changes
+- `RuntimeWarning` replaced by `NeptuneWarning` if model summary or diagram cannot be logged ([#61](https://github.com/neptune-ai/neptune-tensorflow-keras/pull/61))
+
+### Fixes
+- Handled additional kwargs passed to `model.summary()`'s `print_fn` ([#61](https://github.com/neptune-ai/neptune-tensorflow-keras/pull/61))
+
 ## neptune-tensorflow-keras 2.2.1
 
 ### Changes

--- a/src/neptune_tensorflow_keras/impl/__init__.py
+++ b/src/neptune_tensorflow_keras/impl/__init__.py
@@ -41,8 +41,6 @@ except ImportError as exc:
             pip install tensorflow"""
         raise ModuleNotFoundError(msg) from exc
 
-from neptune.common.warnings import NeptuneWarning
-
 from neptune_tensorflow_keras.impl.version import __version__
 
 try:
@@ -164,13 +162,13 @@ class NeptuneCallback(Callback):
             try:
                 self._model_logger["summary"] = _model_summary_file(self.model)
             except ValueError as e:
-                warnings.warn(f"Model summary not logged. {e}", category=NeptuneWarning)
+                warnings.warn(f"Model summary not logged. {e}", category=RuntimeWarning)
 
         if self._log_model_diagram:
             try:
                 self._model_logger["visualization"] = _model_diagram(self.model)
             except ValueError as e:
-                warnings.warn(f"Model visualization not logged. {e}", category=NeptuneWarning)
+                warnings.warn(f"Model visualization not logged. {e}", category=RuntimeWarning)
 
     def on_train_batch_end(self, batch, logs=None):
         if self._log_on_batch:

--- a/src/neptune_tensorflow_keras/impl/__init__.py
+++ b/src/neptune_tensorflow_keras/impl/__init__.py
@@ -41,6 +41,8 @@ except ImportError as exc:
             pip install tensorflow"""
         raise ModuleNotFoundError(msg) from exc
 
+from neptune.common.warnings import NeptuneWarning
+
 from neptune_tensorflow_keras.impl.version import __version__
 
 try:
@@ -162,13 +164,13 @@ class NeptuneCallback(Callback):
             try:
                 self._model_logger["summary"] = _model_summary_file(self.model)
             except ValueError as e:
-                warnings.warn(f"Model summary not logged. {e}", category=RuntimeWarning)
+                warnings.warn(f"Model summary not logged. {e}", category=NeptuneWarning)
 
         if self._log_model_diagram:
             try:
                 self._model_logger["visualization"] = _model_diagram(self.model)
             except ValueError as e:
-                warnings.warn(f"Model visualization not logged. {e}", category=RuntimeWarning)
+                warnings.warn(f"Model visualization not logged. {e}", category=NeptuneWarning)
 
     def on_train_batch_end(self, batch, logs=None):
         if self._log_on_batch:
@@ -190,7 +192,7 @@ class NeptuneCallback(Callback):
 
 def _model_summary_file(model) -> File:
     stream = io.StringIO()
-    model.summary(print_fn=lambda x: stream.write(x + "\n"))
+    model.summary(print_fn=lambda x, **kwargs: stream.write(x + "\n"))
     return File.from_stream(stream, extension="txt")
 
 


### PR DESCRIPTION
### Changes
- `RuntimeWarning` replaced by `NeptuneWarning` if model summary or diagram cannot be logged

### Fixes
- Handled additional kwargs passed to `model.summary()`'s `print_fn`